### PR TITLE
upgrade-db: Remove time-offset for xl migration.

### DIFF
--- a/upgrade-db/Migrations/M_34.hs
+++ b/upgrade-db/Migrations/M_34.hs
@@ -43,4 +43,5 @@ updateGuests = xformVmJSON xform where
     where
       modify = jsSet "/v4v-firewall-rules/4" (jsBoxString "my-stubdom -> 0:5100") .
                jsMv "/config/acpi-pt"   "/config/acpi-path" .
-               jsRm "/config/smbios-pt"
+               jsRm "/config/smbios-pt" .
+               jsRm "/time-offset"


### PR DESCRIPTION
I am not sure what time-offset was expected to do, but the way it's currently written to the xl config is not valid. It causes the error shown in Capture.JPG in OXT-1059.